### PR TITLE
ENH: Allow reading s-rep from csv files

### DIFF
--- a/src/CSVloaderQT.cxx
+++ b/src/CSVloaderQT.cxx
@@ -55,13 +55,13 @@ void CSVloaderQT::on_buttonBox_accepted()
     for (int i = 0; i < fileList.size(); i++)
     {
         QString QFilePath = fileList[i].absoluteFilePath();
-        if (!QFilePath.endsWith(".vtk") && !QFilePath.endsWith(".vtp"))
+        if (!QFilePath.endsWith(".vtk") && !QFilePath.endsWith(".vtp") && !QFilePath.endsWith(".xml"))
         {
             fileList.removeAt(i);
             i--;
             std::ostringstream strs;
             strs << QFilePath.toStdString() << std::endl
-                 << "This is not a vtk/vtp file."<< std::endl;
+                 << "This is not a vtk/vtp/xml file."<< std::endl;
             QMessageBox::critical(this,"Wrong file format",QString(strs.str().c_str()), QMessageBox::Ok);
         }
         else if(!fileList[i].exists())


### PR DESCRIPTION
@vicory Could you take a look and merge this? The SVA uses csv file for previewing the selected shapes in SPV. I would like NOT to make any major change to the existing previewing pipeline. So probably just allowing xml files appearing in the csv file would work. 
@bpaniagua fyi 