### PR TITLE
ENH: Allow SPV to read .fcsv fiducial files

### DIFF
--- a/src/ShapePopulationData.cxx
+++ b/src/ShapePopulationData.cxx
@@ -202,6 +202,17 @@ void ShapePopulationData::ReadSRep(vtkPolyData* upPD, vtkPolyData* downPD, vtkPo
 
 void ShapePopulationData::ReadFiducial(const std::string& a_filePath)
 {
+    size_t found = a_filePath.find_last_of("/\\");
+    if (found != std::string::npos)
+    {
+      m_FileDir = a_filePath.substr(0,found);
+      m_FileName = a_filePath.substr(found+1);
+    }
+    else
+    {
+      m_FileName = a_filePath;
+    }
+  
     // Read file and record fiducial positions
     QFile inputFile(a_filePath.c_str());
     if (!inputFile.open(QIODevice::ReadOnly | QIODevice::Text))

--- a/src/ShapePopulationData.h
+++ b/src/ShapePopulationData.h
@@ -14,6 +14,7 @@
 #include <vtkPolyData.h>
 #include <vtkPolyDataNormals.h>
 #include <vtkPolyDataReader.h>
+#include <vtkSphereSource.h>
 #include <vtkXMLDataElement.h>
 #include <vtkXMLDataParser.h>
 #include <vtkXMLPolyDataReader.h>
@@ -25,6 +26,10 @@
 #include <algorithm>
 #include <sstream>
 
+#include <QFile>
+#include <QString>
+#include <QTextStream>
+
 class ShapePopulationData
 {
     public :
@@ -35,6 +40,7 @@ class ShapePopulationData
     vtkSmartPointer<vtkPolyData> ReadMesh(std::string a_filePath);
     void ReadMesh(vtkPolyData* polyData, const std::string& a_filePath);
     void ReadSRep(vtkPolyData* upPD, vtkPolyData* downPD, vtkPolyData* crestPD, const std::string& a_filePath);
+    void ReadFiducial(const std::string& a_filePath);
     vtkSmartPointer<vtkPolyData> ReadPolyData(std::string a_filePath);
 
     vtkSmartPointer<vtkPolyData> GetPolyData() {return m_PolyData;}

--- a/src/ShapePopulationQT.cxx
+++ b/src/ShapePopulationQT.cxx
@@ -85,6 +85,7 @@ ShapePopulationQT::ShapePopulationQT(QWidget* parent) : QWidget(parent)
     connect(actionOpen_Directory,SIGNAL(triggered()),this,SLOT(openDirectory()));
     connect(actionOpen_VTK_Files,SIGNAL(triggered()),this,SLOT(openFiles()));
     connect(actionOpen_SRep_Files,SIGNAL(triggered()),this,SLOT(openSRepFiles()));
+    connect(actionOpen_Fiducial_Files,SIGNAL(triggered()),this,SLOT(openFiducialFiles()));
     connect(actionLoad_CSV,SIGNAL(triggered()),this,SLOT(loadCSV()));
     connect(m_CSVloaderDialog,SIGNAL(sig_itemsSelected(QFileInfoList)),this,SLOT(slot_itemsSelected(QFileInfoList)));
     connect(actionDelete,SIGNAL(triggered()),this,SLOT(deleteSelection()));
@@ -213,6 +214,12 @@ void ShapePopulationQT::loadSRepFilesCLP(QFileInfoList a_fileList)
     m_colormapDirectory= file.path();
     gradientWidget_VISU->loadColorPointList(filename, &m_usedColorBar->colorPointList);
     this->updateColorbar_QT();
+}
+
+void ShapePopulationQT::loadFiducialFilesCLP(QFileInfoList a_fileList)
+{
+
+    this->CreateWidgets(a_fileList);
 }
 
 void ShapePopulationQT::loadModel(vtkMRMLModelNode* modelNode)
@@ -388,6 +395,29 @@ void ShapePopulationQT::openSRepFiles()
     this->updateColorbar_QT();
 }
 
+void ShapePopulationQT::openFiducialFiles()
+{
+    QStringList stringList = QFileDialog::getOpenFileNames(this,tr("Open Files"),m_lastDirectory,"Fiducial Files (*.fcsv)");
+    if(stringList.isEmpty())
+    {
+      return ;
+    }
+
+    m_lastDirectory=QFileInfo(stringList.at(0)).path();
+
+    //Add to fileList
+    QFileInfoList fileInfos;
+
+    //Control the files format
+    foreach(const QString& filePath, stringList)
+    {
+      fileInfos.append(QFileInfo(filePath));
+    }
+
+    //Display widgets
+    this->CreateWidgets(fileInfos);
+}
+
 void ShapePopulationQT::loadCSV()
 {
     // get directory
@@ -441,6 +471,7 @@ void ShapePopulationQT::deleteAll()
     actionOpen_Directory->setText("Open Directory");
     actionOpen_VTK_Files->setText("Open VTK Files");
     actionOpen_SRep_Files->setText("Open SRep Files");
+    actionOpen_Fiducial_Files->setText("Open Fiducial Files");
     actionLoad_CSV->setText("Load CSV File");
 
     //Empty the meshes FileInfo List
@@ -1242,6 +1273,7 @@ void ShapePopulationQT::CreateWidgets(const QList<vtkRenderWindow*>& renderWindo
     this->actionOpen_VTK_Files->setText("Add VTK/VTP files");
     this->actionLoad_CSV->setText("Add CSV file");
     this->actionOpen_SRep_Files->setText("Add S-Rep files");
+    this->actionOpen_Fiducial_Files->setText("Add Fiducial files");
 
     /* DISPLAY INFOS */
     this->updateInfo_QT();

--- a/src/ShapePopulationQT.h
+++ b/src/ShapePopulationQT.h
@@ -47,6 +47,7 @@ public:
 
     void loadVTKFilesCLP(QFileInfoList a_fileList);
     void loadSRepFilesCLP(QFileInfoList a_fileList);
+    void loadFiducialFilesCLP(QFileInfoList a_fileList);
     void loadModel(vtkMRMLModelNode* modelNode);
     void loadModel(vtkPolyData* polyData, const QString& modelName);
     void loadCSVFileCLP(QFileInfo file);
@@ -111,6 +112,7 @@ protected:
     void openDirectory();
     void openFiles();
     void openSRepFiles();
+    void openFiducialFiles();
     void loadCSV();
     void slot_itemsSelected(QFileInfoList fileList);
     void deleteAll();

--- a/src/ShapePopulationQT.ui
+++ b/src/ShapePopulationQT.ui
@@ -1661,6 +1661,11 @@ p, li { white-space: pre-wrap; }
     <string>Open S-Rep Files</string>
    </property>
   </action>
+  <action name="actionOpen_Fiducial_Files">
+   <property name="text">
+    <string>Open Fiducial Files</string>
+   </property>
+  </action>
   <action name="actionDelete">
    <property name="text">
     <string>Delete Selection</string>

--- a/src/ShapePopulationViewer.xml
+++ b/src/ShapePopulationViewer.xml
@@ -30,6 +30,15 @@ ShapePopulationViewer is a software that allows you to dynamically interact with
       <description><![CDATA[srep Input files]]></description>
     </geometry>
 
+    <geometry fileExtensions=".fcsv" multiple="true" >
+      <name>FiducialFiles</name>
+      <label>Fiducial Files</label>
+      <channel>input</channel>
+      <longflag>--fiducialfiles</longflag>
+      <flag>-f</flag>
+      <description><![CDATA[.fcsv Input files]]></description>
+    </geometry>
+
     <file fileExtensions=".csv" >
       <name >CSVFile</name>
       <label>Load from CSV File</label>

--- a/src/qSlicerShapePopulationViewerModuleWidget.cxx
+++ b/src/qSlicerShapePopulationViewerModuleWidget.cxx
@@ -192,6 +192,7 @@ void qSlicerShapePopulationViewerModuleWidget::setup()
             << d->ShapePopulationWidget->actionOpen_VTK_Files
             << d->ShapePopulationWidget->actionLoad_CSV
             << d->ShapePopulationWidget->actionOpen_SRep_Files
+            << d->ShapePopulationWidget->actionOpen_Fiducial_Files
     )
     {
         QToolButton* button = new QToolButton();
@@ -279,6 +280,13 @@ void qSlicerShapePopulationViewerModuleWidget::loadSRep(const QString &filePath)
 {
     Q_D(qSlicerShapePopulationViewerModuleWidget);
     d->ShapePopulationWidget->loadSRepFilesCLP(QFileInfoList() << QFileInfo(filePath));
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerShapePopulationViewerModuleWidget::loadFiducial(const QString &filePath)
+{
+    Q_D(qSlicerShapePopulationViewerModuleWidget);
+    d->ShapePopulationWidget->loadFiducialFilesCLP(QFileInfoList() << QFileInfo(filePath));
 }
 
 //-----------------------------------------------------------------------------

--- a/src/qSlicerShapePopulationViewerModuleWidget.h
+++ b/src/qSlicerShapePopulationViewerModuleWidget.h
@@ -54,6 +54,7 @@ public slots:
     void loadModel(vtkPolyData* polydata, const QString& modelName);
     void loadCSVFile(const QString& filePath);
     void loadSRep(const QString& filePath);
+    void loadFiducial(const QString& filePath);
 
     void deleteModels();
 

--- a/src/qSlicerShapePopulationViewerModuleWidget.ui
+++ b/src/qSlicerShapePopulationViewerModuleWidget.ui
@@ -55,7 +55,7 @@
      <property name="text">
       <string>Import</string>
      </property>
-     <layout class="QHBoxLayout" name="ImportLayout">
+     <layout class="QVBoxLayout" name="ImportLayout">
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
@jcfr please take a look and let me know what you think.
There are some issues with building SPV from its origin repo, so I build and test my implementation from the SPV folder under SlicerSALT superbuild and everything works.

Issues with building from the origin repo:
1. If we build SPV as an indenpendent superbuild, the vtk download gets no response. If I remember correctly, this superbuild doesn't not work since long time ago even if there is no issue with vtk build.
2. If we compile SPV as a slicer extension, the cmake will first raise an error about c++ standard diference (SPV c++ 11, Slicer c++ 17). After fixing the CMakeList, the SPV build is not able to find some additional vtk srep library from Connor's implementation (see my comments here https://github.com/slicersalt/ShapePopulationViewer/pull/7 )

@bpaniagua we may want to fix the second issue to facilitate future development when we got time, but none of the issues affects our current SlicerSALT build.